### PR TITLE
Release v0.0.7 + Deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,20 @@
+# Deprecation notice
+
+As of OBS version 28.0.0 (released in 2022-09-01), this plugin no longer works. You can find more details as to why [here](https://gitlab.com/fzwoch/obs-nvfbc/-/issues/6#note_1071642813).
+
+If you really want to use this plugin, you will have to downgrade OBS back to version 27.2.4, using this command:
+
+```bash
+# Remove 'sudo' if you installed OBS only for the current user.
+sudo flatpak update --commit=0069ec300ce09337a585acfcefe0f2ecdfa0efcd08d920b2751c844fd026296a com.obsproject.Studio
+```
+
+And then you'll have to disable Flatpak from auto-updating OBS with:
+
+```bash
+flatpak mask com.obsproject.Studio
+```
+
 # NVFBC plugin for OBS Studio (Flatpak)
 
 This plugin will be useless for you, unless you have a Tesla/Quadro GPU from NVIDIA, **or** patched NVIDIA drivers.

--- a/com.obsproject.Studio.Plugin.NVFBC.metainfo.xml
+++ b/com.obsproject.Studio.Plugin.NVFBC.metainfo.xml
@@ -8,6 +8,7 @@
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-2.0</project_license>
   <releases>
+    <release date="2022-09-02" version="0.0.7"/>
     <release date="2022-04-10" version="0.0.6"/>
     <release date="2021-12-27" version="0.0.5"/>
     <release date="2021-09-29" version="0.0.4"/>

--- a/com.obsproject.Studio.Plugin.NVFBC.yaml
+++ b/com.obsproject.Studio.Plugin.NVFBC.yaml
@@ -10,12 +10,28 @@ build-options:
   prefix: /app/plugins/NVFBC
 modules:
   - name: nvfbc
-    buildsystem: meson
+    buildsystem: simple
+    build-commands:
+      - mkdir obs-devel-27
+      - bsdtar -xf obs-headers-27.rpm -C obs-devel-27
+      - bsdtar -xf obs-libs-27.rpm -C obs-devel-27
+      - meson builddir --prefix=/app/plugins/NVFBC
+      - ninja -C builddir install
     sources:
       - type: git
         url: https://gitlab.com/fzwoch/obs-nvfbc.git
-        tag: v0.0.6
-        commit: fa70f1bcd60145b0e8cdaa600b366adf127af3aa
+        tag: v0.0.7
+        commit: dda5bf49c316a7c5603b7f86dc19b62794d5e588
+      - type: file
+        dest-filename: obs-headers-27.rpm
+        url: https://download1.rpmfusion.org/free/el/updates/8/x86_64/o/obs-studio-devel-27.2.1-1.el8.x86_64.rpm
+        sha256: 789cf76cc184938ff6e8099864ddf78092ce3a5596609dc3e0408d2265079167
+      - type: file
+        dest-filename: obs-libs-27.rpm
+        url: https://download1.rpmfusion.org/free/el/updates/8/x86_64/o/obs-studio-libs-27.2.1-1.el8.x86_64.rpm
+        sha256: 4033b47fe0ab68adadd2e86efa8d056d4cbdd8463fb192d9286d8624c59be5a8
+      - type: patch
+        path: obs-devel-27.patch
   - name: appdata
     buildsystem: simple
     build-commands:

--- a/obs-devel-27.patch
+++ b/obs-devel-27.patch
@@ -1,0 +1,16 @@
+diff --git a/meson.build b/meson.build
+index 2d45c58..1a71eaa 100644
+--- a/meson.build
++++ b/meson.build
+@@ -1,7 +1,10 @@
+ project('obs-nvfbc', 'c', default_options: ['c_std=c99'])
+ 
+ threads = dependency('threads')
+-obs = meson.get_compiler('c').find_library('obs')
++obs = declare_dependency(
++  link_args : ['-L' + meson.source_root() + '/obs-devel-27/usr/lib64/', '-lobs'],
++  include_directories : ['obs-devel-27/usr/include']
++)
+ gl = dependency('gl')
+ if target_machine.system() != 'windows'
+     x11 = dependency('x11')


### PR DESCRIPTION
This release prevents a crash in OBS 28+.

But since the plugin will no longer work, I also added a deprecation notice and instructions on how to downgrade OBS to 27.2.4.

Also see: https://gitlab.com/fzwoch/obs-nvfbc/-/issues/6#note_1071642813